### PR TITLE
👷 ci: Shorten gha commit prefix in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,4 +38,4 @@ updates:
           - "minor"
           - "patch"
     commit-message:
-      prefix: "⬆️ ghaction:"
+      prefix: "⬆️ gha:"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated commit message prefix for Dependabot updates from "⬆️ ghaction:" to "⬆️ gha:".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->