### PR TITLE
✨ variables: validate KMS key ARNs (closes #163)

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -28,6 +28,15 @@ variable "dynamodb_kms_key_arn" {
   default     = null
   description = "[DEPRECATED — only consulted when `enable_legacy_dynamodb_locking = true`.] The ARN of a customer-managed AWS KMS key to use for server-side encryption of the DynamoDB state-lock table. When null, the AWS-managed DynamoDB default key is used."
   nullable    = true
+
+  validation {
+    # Accept null / blank (= use the AWS-managed default, matching the module's
+    # `!= null && trimspace() != ""` usage guard) or a KMS key/alias ARN. The
+    # partition is left open (aws / aws-us-gov / aws-cn) and `key/` allows the
+    # `mrk-` multi-region key prefix.
+    condition     = var.dynamodb_kms_key_arn == null || trimspace(var.dynamodb_kms_key_arn) == "" || can(regex("^arn:aws[a-z-]*:kms:[a-z0-9-]+:[0-9]{12}:(key/[0-9a-zA-Z-]+|alias/[a-zA-Z0-9/_-]+)$", trimspace(var.dynamodb_kms_key_arn)))
+    error_message = "dynamodb_kms_key_arn must be null, empty, or a valid KMS key or alias ARN (e.g. arn:aws:kms:us-east-1:123456789012:key/<id> or .../alias/<name>)."
+  }
 }
 
 variable "s3_kms_key_arn" {
@@ -35,4 +44,13 @@ variable "s3_kms_key_arn" {
   default     = null
   description = "The ARN of a customer-managed AWS KMS key to use for server-side encryption of the S3 Terraform state bucket. When null, the AWS-managed S3 default key (aws/s3) is used."
   nullable    = true
+
+  validation {
+    # Accept null / blank (= use the AWS-managed default, matching the module's
+    # `!= null && trimspace() != ""` usage guard) or a KMS key/alias ARN. The
+    # partition is left open (aws / aws-us-gov / aws-cn) and `key/` allows the
+    # `mrk-` multi-region key prefix.
+    condition     = var.s3_kms_key_arn == null || trimspace(var.s3_kms_key_arn) == "" || can(regex("^arn:aws[a-z-]*:kms:[a-z0-9-]+:[0-9]{12}:(key/[0-9a-zA-Z-]+|alias/[a-zA-Z0-9/_-]+)$", trimspace(var.s3_kms_key_arn)))
+    error_message = "s3_kms_key_arn must be null, empty, or a valid KMS key or alias ARN (e.g. arn:aws:kms:us-east-1:123456789012:key/<id> or .../alias/<name>)."
+  }
 }


### PR DESCRIPTION
Closes #163.

Adds fail-fast validation to `s3_kms_key_arn` and `dynamodb_kms_key_arn` — a malformed ARN now errors at `terraform plan` with a clear message instead of surfacing as an opaque AWS API error mid-`apply`.

## Rule
Each accepts: `null` / blank **or** a KMS **key or alias** ARN.

```
^arn:aws[a-z-]*:kms:[a-z0-9-]+:[0-9]{12}:(key/[0-9a-zA-Z-]+|alias/[a-zA-Z0-9/_-]+)$
```

Null/blank is accepted on purpose — it's the documented "use the AWS-managed default key" path, and it matches the module's own usage guard (`var.x != null && trimspace(var.x) != ""`). The regex is applied to `trimspace(var.x)` for the same reason.

## Deviations from the issue's suggested regex
The issue proposed `^arn:aws:kms:[a-z0-9-]+:[0-9]{12}:key/[a-f0-9-]+$`, which has three gaps I fixed:
- **partition-locked** to `aws` → rejects `aws-us-gov` / `aws-cn`. Opened to `aws[a-z-]*`.
- **key-ARN-only** → rejects **alias ARNs**, which S3 `kms_master_key_id` and DynamoDB `server_side_encryption.kms_key_arn` both accept. Added the `alias/` form.
- **`[a-f0-9-]`** → rejects `mrk-` **multi-region keys**. Widened the key segment.

## Testing
14 positive/negative cases, all green: null, empty, blank-spaces, valid key ARN, alias ARN (incl. `alias/aws/s3`), gov partition, `mrk-` key, whitespace-wrapped ARN → accept; bare key id, `arn:aws:s3:::bucket`, short account, junk → reject. `terraform fmt` + full `validate` clean; README untouched (validation blocks don't render in terraform-docs).

@oldmanbendobot — second of the validation-rules sweep (apigateway#76 landed already). your eyes when you've got a sec? ♡ 🐱