### PR TITLE
🐱 beat-2 pilot: codeql → reusable caller (SHA-pinned)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,15 +1,13 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
+# Thin caller -> reusable CodeQL in bendoerr-terraform-modules/workflows.
+# CodeQL is the org's ONE required gate (the `code_scanning` ruleset rule, which keys on the SARIF
+# tool name `CodeQL` that codeql-action/analyze uploads — not a check-run name). GATE-DEFINER ->
+# SHA-pinned (not @v1): a bad push to the reusable must never be able to break the merge gate org-wide.
 #
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
-name: "CodeQL Advanced"
+# Triggers MIRROR this repo's prior advanced setup (push + pull_request + schedule) so analysis runs on
+# PR heads -> code_scanning resolves on real signal, not staleness off the last main run.
+# Caller MUST grant security-events: write (perms are caller-capped) or the SARIF upload 403s and the
+# gate never resolves. This repo rides the reusable defaults (actions+go matrix, test/go.mod, egress).
+name: CodeQL Advanced
 
 on:
   push:
@@ -24,99 +22,9 @@ permissions:
 
 jobs:
   analyze:
-    name: Analyze (${{ matrix.language }})
-    # Runner size impacts CodeQL analysis time. To learn more, please see:
-    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
-    #   - https://gh.io/supported-runners-and-hardware-resources
-    #   - https://gh.io/using-larger-runners (GitHub.com only)
-    # Consider using larger runners or machines with greater resources for possible analysis time improvements.
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
     permissions:
-      # required for all workflows
       security-events: write
-
-      # required to fetch internal or private CodeQL packs
       packages: read
-
-      # only required for workflows in private repositories
       actions: read
       contents: read
-
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - language: actions
-            build-mode: none
-          - language: go
-            build-mode: autobuild
-        # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift'
-        # Use `c-cpp` to analyze code written in C, C++ or both
-        # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
-        # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
-        # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,
-        # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
-        # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
-        # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
-        with:
-          egress-policy: block
-          allowed-endpoints: >
-            api.github.com:443
-            cdn.fwupd.org:443
-            github.com:443
-            hosted-compute-watchdog-prod-eus-01.githubapp.com:443
-            objects.githubusercontent.com:443
-            packages.microsoft.com:443
-            proxy.golang.org:443
-            storage.googleapis.com:443
-            uploads.github.com:443
-
-      - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      # Add any setup steps before running the `github/codeql-action/init` action.
-      # This includes steps like installing compilers or runtimes (`actions/setup-node`
-      # or others). This is typically only required for manual builds.
-      # - name: Setup runtime (example)
-      #   uses: actions/setup-example@v1
-      - if: matrix.language == 'go'
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          go-version-file: test/go.mod
-
-      # Initializes the CodeQL tools for scanning.
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3.29.5
-        with:
-          languages: ${{ matrix.language }}
-          build-mode: ${{ matrix.build-mode }}
-          # If you wish to specify custom queries, you can do so here or in a config file.
-          # By default, queries listed here will override any specified in a config file.
-          # Prefix the list here with "+" to use these queries and those in the config file.
-
-          # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-          # queries: security-extended,security-and-quality
-
-      # If the analyze step fails for one of the languages you are analyzing with
-      # "We were unable to automatically build your code", modify the matrix above
-      # to set the build mode to "manual" for that language. Then modify this step
-      # to build your code.
-      # ℹ️ Command-line programs to run using the OS shell.
-      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-      - if: matrix.build-mode == 'manual'
-        shell: bash
-        run: |
-          echo 'If you are using a "manual" build mode for one or more of the' \
-            'languages you are analyzing, replace this with the commands to build' \
-            'your code, for example:'
-          echo '  make bootstrap'
-          echo '  make release'
-          exit 1
-
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v3.29.5
-        with:
-          category: "/language:${{matrix.language}}"
+    uses: bendoerr-terraform-modules/workflows/.github/workflows/codeql.yml@3528f5063d9677242907e8083d2e23d262017f48

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,4 +27,4 @@ jobs:
       packages: read
       actions: read
       contents: read
-    uses: bendoerr-terraform-modules/workflows/.github/workflows/codeql.yml@3528f5063d9677242907e8083d2e23d262017f48
+    uses: bendoerr-terraform-modules/workflows/.github/workflows/codeql.yml@c2b51a26bb2c70baa655258fd44741345e4c9e95


### PR DESCRIPTION
**Beat-2 pilot — the gate rehearsal.** First consumer of the reusable CodeQL (`workflows@3528f506`). CodeQL is the org's *only* required status gate (`code_scanning` ruleset rule), so this is where we prove a real gate survives the reusable cutover **before** it touches the other 5 advanced repos.

## what
Replaces this repo's per-repo `codeql.yml` (112 lines) with a 10-line caller:
```yaml
jobs:
  analyze:
    permissions: { security-events: write, packages: read, actions: read, contents: read }
    uses: bendoerr-terraform-modules/workflows/.github/workflows/codeql.yml@3528f5063d9677242907e8083d2e23d262017f48
```
SHA-pinned (gate-definer → not `@v1`). Rides the reusable defaults (actions+go matrix, `test/go.mod`, egress) — verified byte-equivalent to this repo's prior config.

## acceptance criterion (Lilith's catch — this is the whole point)
**`code_scanning` must resolve GREEN on THIS PR's head, pre-merge** — not green-by-staleness off the last main run. Triggers mirror the prior setup (`push` + `pull_request` + `schedule`) so analysis runs on the PR head. If it sits at "Expected — waiting," the new tool-binding never exercised on a PR head = **do not merge**, debug here (fail-before-commit).

## what to watch
1. `analyze / Analyze (actions)` + `analyze / Analyze (go)` run green (rename is cosmetic — no `required_status_checks`)
2. SARIF uploads under tool **`CodeQL`** → **`code_scanning` resolves on this PR head**
3. `security-events: write` on the caller is what lets the upload succeed (caller-capped perms)

Green here = the gate survives the reusable, and fan-out to the other 5 (defaults, cf-and-s3, tfuser, null-context, null-label — all ride defaults) is mechanical. @oldmanbendobot on the perch 🦅