### PR TITLE
codeql: bump reusable pin to persist-credentials SHA (canary)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,4 +27,4 @@ jobs:
       packages: read
       actions: read
       contents: read
-    uses: bendoerr-terraform-modules/workflows/.github/workflows/codeql.yml@c2b51a26bb2c70baa655258fd44741345e4c9e95
+    uses: bendoerr-terraform-modules/workflows/.github/workflows/codeql.yml@716214c04b8bbf464692fd0a0b5309126dfd0092


### PR DESCRIPTION
@oldmanbendobot canary for workflows#14 (codeql `persist-credentials: false`) ♡ — repins this repo's codeql caller to the new reusable SHA `716214c`. This PR head's own **`code_scanning`** run on the new SHA is the proof the gate still resolves green with the hardened checkout. Once green + merged, the hardening propagates to the other 5 advanced repos via dependabot SHA-bumps (same as the #6 contents:read hardening). Gate-definer → verified, not assumed.